### PR TITLE
Adds config settings and GPIO control for step resolution pins

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,27 +1,39 @@
 {
-    "botID": "drawbot",
-    "swapDirections": [
-        true,
-        true
-    ],
-    "localPort": 80,
-    "baseDelay": 2,
-    "d": 1000,
-    "startPos": {
-      "x": 100,
-      "y": 100
+  "botID": "drawbot",
+  "swapDirections": [
+    true,
+    true
+  ],
+  "localPort": 80,
+  "baseDelay": 2,
+  "d": 1000,
+  "startPos": {
+    "x": 100,
+    "y": 100
+  },
+  "stepsPerMM": [
+    10,
+    10
+  ],
+  "penPauseDelay": 400,
+  "remoteURL": "",
+  "pins": {
+    "leftDir": 20,
+    "rightDir": 6,
+    "leftStep": 21,
+    "rightStep": 13,
+    "penServo": 18
+  },
+  "stepResolutionPins": {
+    "leftMotor": {
+      "ms1": 2,
+      "ms2": 3,
+      "ms3": 4
     },
-    "stepsPerMM": [
-      10,
-      10
-    ],
-    "penPauseDelay": 400,
-    "remoteURL": "",
-    "pins": {
-      "leftDir": 20,
-      "rightDir": 6,
-      "leftStep": 21,
-      "rightStep": 13,
-      "penServo": 18
+    "rightMotor": {
+      "ms1": 17,
+      "ms2": 27,
+      "ms3": 22,
     }
+  }
 }

--- a/modules/BotController.js
+++ b/modules/BotController.js
@@ -35,6 +35,29 @@ var BotController = (cfg) => {
     // set up servo GPIO pin
     var servo = new Gpio(config.pins.penServo, gmOut)
 
+    // ^ Step resolution Pins
+    const leftMotorMs1= new Gpio(config.stepResolutionPins.leftMotor.ms1, gmOut)
+    const leftMotorMs2= new Gpio(config.stepResolutionPins.leftMotor.ms2, gmOut)
+    const leftMotorMs3= new Gpio(config.stepResolutionPins.leftMotor.ms3, gmOut)
+    const rightMotorMs1= new Gpio(config.stepResolutionPins.rightMotor.ms1, gmOut)
+    const rightMotorMs2= new Gpio(config.stepResolutionPins.rightMotor.ms2, gmOut)
+    const rightMotorMs3= new Gpio(config.stepResolutionPins.rightMotor.ms3, gmOut)
+
+    // ^ Step resolution settings
+    // * Were configuring our driver for an Eighth Step resolution. Also note that these pinouts
+    // * correspond to the A4988 StepStick stepper motor driver:
+    // ? https://www.pololu.com/product/1182
+    // 
+    // * We're not adjusting the values on the fly so they can be set here and not touched, but if your resolution
+    // * needs to vary at runtime you can adjust the values of these pins. More information 
+    // * on pin configurations can be found here:
+    // ? https://howtomechatronics.com/tutorials/arduino/how-to-control-stepper-motor-with-a4988-driver-and-arduino/
+    leftMotorMs1.digitalWrite(1)
+    leftMotorMs2.digitalWrite(1)
+    leftMotorMs3.digitalWrite(0)
+    rightMotorMs1.digitalWrite(1)
+    rightMotorMs2.digitalWrite(1)
+    rightMotorMs3.digitalWrite(0)
 
     /////////////////////////////////
     // CONTROLLER VARIABLES


### PR DESCRIPTION
This commit makes the step resolution pins on the stepper motor drivers configurable and controllable at runtime. 

The settings are aimed at the A4988 step stick, but should be usable by other stepper motor drivers. 